### PR TITLE
feat: local screenshare with single peer

### DIFF
--- a/golang/static/examples/screenshare.html
+++ b/golang/static/examples/screenshare.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      video {
+        height: 320px;
+        width: 480px;
+      }
+      .mute, .start {
+        cursor: pointer;
+      }
+    </style>
+    <script type="text/javascript">
+      async function stopCapture(evt) {
+        const localMedia = document.querySelector('#local')
+        let tracks = localMedia.srcObject.getTracks();
+
+        tracks.forEach(track => track.stop());
+        localMedia.srcObject = null;
+      }
+      async function start() {
+        // Poly from https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
+        // Older browsers might not implement mediaDevices at all, so we set an empty object first
+        if (navigator.mediaDevices === undefined) {
+          navigator.mediaDevices = {};
+        }
+
+        // Some browsers partially implement displayMedia. We can't just assign an object
+        // with getDisplayMedia as it would overwrite existing properties.
+        // Here, we will just add the getUserMedia property if it's missing.
+        if (navigator.mediaDevices.getDisplayMedia === undefined) {
+          navigator.mediaDevices.getDisplayMedia = function(constraints) {
+
+            // First get ahold of the legacy getDisplayMedia, if present
+            let getDisplayMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+
+            // Some browsers just don't implement it - return a rejected promise with an error
+            // to keep a consistent interface
+            if (!getDisplayMedia) {
+              return Promise.reject(new Error('getDisplayMedia is not implemented in this browser'));
+            }
+
+            // Otherwise, wrap the call to the old navigator.getDisplayMedia with a Promise
+            return new Promise(function(resolve, reject) {
+              getDisplayMedia.call(navigator, constraints, resolve, reject);
+            });
+          }
+        }
+
+        /*
+        
+        https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture#Options_and_constraints
+
+        getDisplayMedia() is most commonly used to capture video of a user's screen (or parts thereof). However, user agents may allow the capture of audio along with the video content. The source of this audio might be the selected window, the entire computer's audio system, or the user's microphone (or a combination of all of the above).
+         */
+        
+        const stream =  await navigator.mediaDevices.getDisplayMedia(
+          {
+            audio: {
+              echoCancellation: true,
+              noiseSuppression: true,
+              sampleRate: 44100
+            },
+            video: true
+          }
+        )
+        const localMedia = document.querySelector('#local')
+        localMedia.srcObject = stream
+
+        const remoteMedia = document.querySelector('#remote')
+
+        const pc1 = new RTCPeerConnection() 
+        const pc2 = new RTCPeerConnection()
+
+        pc1.addEventListener('icecandidate', ({candidate}) => {
+          if (candidate) {
+            pc2.addIceCandidate(candidate)
+          }
+        })
+
+        pc2.addEventListener('icecandidate', ({candidate}) => {
+          if (candidate) {
+            pc1.addIceCandidate(candidate)
+          }
+        })
+        
+        pc2.addEventListener("track", (track) => {
+          remoteMedia.srcObject = track.streams[0]
+        })
+
+        stream.getTracks().forEach((track) => {
+          pc1.addTrack(track, stream)
+        })
+
+        const offer = await pc1.createOffer({
+          offerToReceiveVideo: 1,
+          offerToReceiveAudio: 1,
+        })
+        await pc1.setLocalDescription(offer)
+        await pc2.setRemoteDescription(offer)
+
+        const answer = await pc2.createAnswer();
+        await pc2.setLocalDescription(answer)
+        await pc1.setRemoteDescription(answer)
+      }
+    </script>
+  </head>
+  <body>
+    <div>
+      <p>
+        Local
+      </p>
+      <video id="local" autoplay controls></video>
+    </div>
+    <div>
+      <p>
+        Remote
+      </p>
+      <video id="remote" autoplay controls></video>
+    </div>
+    <input id="start" class="start" type="button" value="Start Screenshare" onclick="start()"/>
+    <input id="start" class="start" type="button" value="Stop Screenshare" onclick="stopCapture()"/>
+  </body>
+</html>


### PR DESCRIPTION
Implements getDisplayMedia() static example from (https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture#Options_and_constraints)

Single peer start/stop share with app/screen/device selection including audio track from current MediaTrack.