### PR TITLE
fix: default origin checking function returns true to allow all HTTP …

### DIFF
--- a/golang/pkg/signaling/server.go
+++ b/golang/pkg/signaling/server.go
@@ -13,12 +13,6 @@ var upgrader = websocket.Upgrader{
 	WriteBufferSize: 1024,
 }
 
-upgrader.CheckOrigin = func(r *http.Request) bool {
-  // do some kind of validation logic here
-  logrus.Debugf("Header contains origin %s", r.Header["Origin"]) // file://file:///Users/adam/Projects/adam-club/golang/static/index.html
-  return true
-}
-
 type Server struct {
 	room *Room
 }
@@ -30,6 +24,11 @@ func NewServer(room *Room) *Server {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	upgrader.CheckOrigin = func(r *http.Request) bool {
+		// do some kind of validation logic here.
+		logrus.Debugf("Header contains origin %s", r.Header["Origin"])
+		return true
+	}
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		logrus.Error(errors.Wrap(err, "problem upgrading to websockets"))

--- a/golang/pkg/signaling/server.go
+++ b/golang/pkg/signaling/server.go
@@ -13,6 +13,12 @@ var upgrader = websocket.Upgrader{
 	WriteBufferSize: 1024,
 }
 
+upgrader.CheckOrigin = func(r *http.Request) bool {
+  // do some kind of validation logic here
+  logrus.Debugf("Header contains origin %s", r.Header["Origin"]) // file://file:///Users/adam/Projects/adam-club/golang/static/index.html
+  return true
+}
+
 type Server struct {
 	room *Room
 }

--- a/golang/static/index.html
+++ b/golang/static/index.html
@@ -56,8 +56,7 @@
         })
 
         let isHTTPS = location.protocol !== 'https:'
-        signals.connect((isHTTPS ? "ws" : "wss") + "://localhost:3001/room")
-        console.log(location.host)
+        signals.connect((isHTTPS ? "ws" : "wss") + "://" + location.host + "/room")
         window.addEventListener("unload", function() {
           signals.sendLeave()
         });

--- a/golang/static/index.html
+++ b/golang/static/index.html
@@ -7,9 +7,9 @@
         width: 33%;
       }
     </style>
-    <script src="/js/localmedia.js"></script>
-    <script src="/js/peering.js"></script>
-    <script src="/js/signaling.js"></script>
+    <script src="./js/localmedia.js"></script>
+    <script src="./js/peering.js"></script>
+    <script src="./js/signaling.js"></script>
   </head>
   <body>
     <div id="videos">
@@ -56,8 +56,8 @@
         })
 
         let isHTTPS = location.protocol !== 'https:'
-        signals.connect((isHTTPS ? "ws" : "wss") + "://" + location.host + "/room")
-
+        signals.connect((isHTTPS ? "ws" : "wss") + "://localhost:3001/room")
+        console.log(location.host)
         window.addEventListener("unload", function() {
           signals.sendLeave()
         });


### PR DESCRIPTION
The Upgrader calls the function specified in the CheckOrigin field to check the origin. If the CheckOrigin function returns false, then the Upgrade method fails the WebSocket handshake with HTTP status 403.

If the CheckOrigin field is nil, then the Upgrader uses a safe default: fail the handshake if the Origin request header is present and the Origin host is not equal to the Host request header.

https://www.gorillatoolkit.org/pkg/websocket
gorilla/websocket#398
gorilla/websocket#367

I've submitted a fix for this: https://github.com/tsmada/club/tree/go-origin-check / https://github.com/tsmada/club/blob/e9902235c9947129787910d240f83774d84dc393/golang/pkg/signaling/server.go#L16

Take a look when you get a minute. We'll want Ryan and others to weigh in here on how we want to handle specific origins (CORS?).