### PR TITLE
Adds examples/mirror.html

### DIFF
--- a/golang/Makefile
+++ b/golang/Makefile
@@ -35,3 +35,9 @@ run: build
 
 run-debug: build
 	ENV=local ./backend
+
+run-pretty: build
+	# open http://localhost:3001
+	ENV=local ./backend 2>&1 | jq --raw-output '[("# " + .level + (" " * 10))[0:10], (.func + (" " * 20))[0:20], .msg] | @tsv'
+
+

--- a/golang/pkg/signaling/room_node.go
+++ b/golang/pkg/signaling/room_node.go
@@ -63,9 +63,9 @@ func (r *Room) Receive(message Message) {
 		var group ReceiverGroup
 
 		// When joining a group, make sure to remove them from their previous group
-		recevier := member.GetParent()
+		receiver := member.GetParent()
 		if group != nil {
-			group = r.GetGroup(recevier.ID())
+			group = r.GetGroup(receiver.ID())
 			group.RemoveMember(member)
 			member.SetParent(nil)
 		}

--- a/golang/pkg/signaling/websocket_peer.go
+++ b/golang/pkg/signaling/websocket_peer.go
@@ -49,7 +49,7 @@ func NewWebsocketPeer(conn WebsocketConn, parent ReceiverNode) *WebsocketPeer {
 func (p *WebsocketPeer) Receive(message Message) {
 	logrus.Debugf("queueing message for %s", p.ID())
 	p.messages <- message
-	logrus.Debugf("finshed queuing message for %s", p.ID())
+	logrus.Debugf("finished queuing message for %s", p.ID())
 }
 
 func (p *WebsocketPeer) PumpWrite() {

--- a/golang/static/examples/mirror.html
+++ b/golang/static/examples/mirror.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <style type="text/css">
+    div#videos>video {
+      display: inline-block;
+      width: 33%;
+    }
+
+    #background {
+      border: 5px solid red;
+      display: none;
+    }
+    canvas {
+      background-color: #ccc;
+      width: 33%;
+      display: none;
+    }
+
+  </style>
+  <script src="/js/event-target.js"></script>
+  <script src="/js/mirrormedia.js"></script>
+  <script src="/js/peering.js"></script>
+  <script src="/js/signaling.js"></script>
+</head>
+
+<body>
+  <!-- https://png-pixel.com -->
+  <img
+    id="background"
+    src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==">
+
+  <canvas id="canvas" style="border:1px solid #d3d3d3;">
+  Your browser does not support the HTML5 canvas tag.
+  </canvas>
+
+  <div id="videos">
+    <video
+      controls=1 id="local" autoplay muted></video>
+  </div>
+
+  <script type="text/javascript">
+    var mirrorBackground = document.getElementById('background')
+    var mirrorVideo = document.getElementById('local')
+    var mirrorCanvas = document.getElementById('canvas')
+    let mirror = new MirrorMedia(mirrorVideo, mirrorCanvas)
+    let text = 'Mirror, Mirror, on the Wall... '
+    let remotePeerId = null
+
+    mirror.setupMedia().then(() => {
+      const framesPerTextScroll = 10
+      let framesUntilTextScroll = framesPerTextScroll
+      const ctx = mirrorCanvas.getContext('2d')
+
+      setInterval(() => {
+        let image = mirrorBackground
+
+        if (remotePeerId) {
+          const remoteVideo = document.getElementById(remotePeerId)
+          if (remoteVideo) {
+            mirrorCanvas.width = remoteVideo.videoWidth
+            mirrorCanvas.height = remoteVideo.videoHeight
+            image = remoteVideo
+          }
+        }
+        ctx.fillStyle = 'darkslateblue'
+        ctx.fillRect(0, 0, mirrorCanvas.width, mirrorCanvas.height)
+        ctx.drawImage(image, 0, 0, mirrorCanvas.width, mirrorCanvas.height)
+        ctx.font = 'italic 40pt Calibri'
+        ctx.fillStyle = 'lightgreen'
+        ctx.fillText(text, 10, mirrorCanvas.height / 2)
+
+        --framesUntilTextScroll
+        if (--framesUntilTextScroll === 0) {
+          framesUntilTextScroll = framesPerTextScroll
+          text = text.slice(1) + text.slice(0, 1)
+        }
+      }, 100)
+
+      let signals = new SignalingServer()
+      let peers = new Peering("videos", mirror.getStream(), signals)
+
+      signals.addEventListener("connected", async (event) => {
+        await mirror.onConnected()
+        await peers.onConnected()
+        signals.sendJoin()
+      })
+
+      signals.addEventListener("join", async (event) => {
+        let offer = await peers.onJoin(event.detail)
+        remotePeerId = event.detail.peerId
+        console.log('join remotePeerId', remotePeerId);
+        signals.sendOffer(event.detail.peerId, offer)
+      })
+
+      signals.addEventListener("leave", async (event) => {
+        await peers.onLeave(event.detail)
+      })
+
+      signals.addEventListener("offer", async (event) => {
+        remotePeerId = event.detail.peerId
+        console.log('offer remotePeerId', remotePeerId);
+        let answer = await peers.onOffer(event.detail)
+        signals.sendAnswer(event.detail.peerId, answer)
+      })
+
+      signals.addEventListener("icecandidate", async (event) => {
+        peers.onICECandidate(event.detail)
+      })
+
+      signals.addEventListener("answer", async (event) => {
+        await peers.onAnswer(event.detail)
+      })
+
+      signals.addEventListener("disconnected", async (event) => {
+        await mirror.onDisconnected()
+        await peers.onDisconnected()
+      })
+
+      let isHTTPS = location.protocol !== 'https:'
+      signals.connect((isHTTPS ? "ws" : "wss") + "://" + location.host + "/room")
+      window.addEventListener("unload", function () {
+        signals.sendLeave()
+      })
+    })
+  </script>
+</body>
+
+</html>

--- a/golang/static/index.html
+++ b/golang/static/index.html
@@ -62,9 +62,17 @@
       signals.connect((isHTTPS ? "ws" : "wss") + "://" + location.host + "/room")
       window.addEventListener("unload", function () {
         signals.sendLeave()
-      });
+      })
     })
   </script>
+
+  <hr>
+  <a href="/examples/audio.html">audio.html</a>
+  <a href="/examples/groups.html">groups.html</a>
+  <a href="/examples/local.html">local.html</a>
+  <a href="/examples/peer.html">peer.html</a>
+  <a href="/examples/peer.html">stun.html</a>
+  <a href="/examples/mirror.html">mirror.html</a>
 </body>
 
 </html>

--- a/golang/static/js/mirrormedia.js
+++ b/golang/static/js/mirrormedia.js
@@ -1,0 +1,25 @@
+
+// eslint-disable-next-line no-unused-vars
+class MirrorMedia {
+  constructor(video, canvas) {
+    this.id = video.id
+    this.video = video
+    this.canvas = canvas
+    this.stream = null
+  }
+
+  async setupMedia() {
+    const stream = this.canvas.captureStream(25)
+
+    this.stream = stream
+
+    this.video.srcObject = stream
+  }
+
+  getStream() {
+    return this.stream
+  }
+
+  async onConnected() {}
+  async onDisconnected() {}
+}

--- a/golang/static/js/peering.js
+++ b/golang/static/js/peering.js
@@ -73,8 +73,15 @@ class Peering {
     let video = document.createElement("video")
     video.id = peerId
     video.autoplay = true
+    video.controls = true
+    video.muted = true
+    video.poster = 'https://upload.wikimedia.org/wikipedia/commons/d/d3/WUERFEL5_0-_bis_5-dimensionale_Wuerfelanaloge.png'
 
     this.videosElm.appendChild(video)
+
+    setTimeout(() => {
+      video.play()
+    }, 1000)
 
     peer.addEventListener('icecandidate', ({ candidate }) => {
       if (candidate) {


### PR DESCRIPTION
- Adds 'make run-pretty' option to format log output in a more human-readable way.
- Fixes typos in a couple places
- Adds static/examples/mirror.html, which synthesizes a video source and acts as a peer.
- Adds links to other examples to bottom of static/index.html
- Adds js/mirrormedia.js which uses a Canvas to create a peer video stream.
- In peering.js, add a 1-second delay before manually firing .play() on a newly created video element. This resolves random issues where even an autoplay video element doesn't start playing automatically.