### PR TITLE
Fixed two bugs

### DIFF
--- a/frontend/src/components/peer_remote/index.js
+++ b/frontend/src/components/peer_remote/index.js
@@ -65,7 +65,9 @@ const PeerRemote = ({ id, localStream }) => {
 
   useEffect(() => {
     peer.addEventListener('icecandidate', ({ candidate }) => {
-      if (candidate) {
+      // Some browsers (non-FF) do not support end-of-candidate message
+      // don't relay those message to peers
+      if (candidate && candidate.candidate !== "") {
         ws.sendICECandidate(id, candidate)
       }
     })
@@ -93,7 +95,11 @@ const PeerRemote = ({ id, localStream }) => {
           await peer.setRemoteDescription(event)
           break
         case 'icecandidate':
-          await peer.addIceCandidate(event)
+          if (event.candidate === "") {
+            await peer.addIceCandidate(null)
+          } else {
+            await peer.addIceCandidate(event)
+          }
           break
         default:
           console.log('unknown event', event)

--- a/frontend/src/components/peer_remote/index.js
+++ b/frontend/src/components/peer_remote/index.js
@@ -67,7 +67,7 @@ const PeerRemote = ({ id, localStream }) => {
     peer.addEventListener('icecandidate', ({ candidate }) => {
       // Some browsers (non-FF) do not support end-of-candidate message
       // don't relay those message to peers
-      if (candidate && candidate.candidate !== "") {
+      if (candidate && candidate.candidate !== '') {
         ws.sendICECandidate(id, candidate)
       }
     })
@@ -95,7 +95,7 @@ const PeerRemote = ({ id, localStream }) => {
           await peer.setRemoteDescription(event)
           break
         case 'icecandidate':
-          if (event.candidate === "") {
+          if (event.candidate === '') {
             await peer.addIceCandidate(null)
           } else {
             await peer.addIceCandidate(event)

--- a/frontend/src/websocket.js
+++ b/frontend/src/websocket.js
@@ -36,10 +36,9 @@ export default ({ children }) => {
         throw new Error('unknown peerID')
       }
 
-      peerEventListeners[peerID] = lodash.remove(
-        peerEventListeners[peerID],
-        listener
-      )
+      lodash.remove(peerEventListeners[peerID], (item) => {
+        return item === listener
+      })
     }
 
     const notifyPeerEventListeners = (peerID, type, event) => {


### PR DESCRIPTION
* Firefox follows a more up-to-date version of the RTC spect (specifically Trickle ICE). It sends a candidate with `candidate=""` (end-of-candidates signal), which causes Safari to throw an error. Chrome does not error. Updated logic to not send such messages to peers. 
* Fixed bad call of Lodash remove that was not removing listeners 